### PR TITLE
Fix DigitalOcean.Response to support empty body

### DIFF
--- a/lib/digital_ocean/response.ex
+++ b/lib/digital_ocean/response.ex
@@ -13,9 +13,10 @@ defmodule DigitalOcean.Response do
   @spec new(Http.response_t(), Config.t()) :: t
   def new(response, config) do
     body =
-      response
-      |> Map.get(:body)
-      |> config.json_codec.decode!()
+      case Map.get(response, :body) do
+        "" -> ""
+        body -> config.json_codec.decode!(body)
+      end
 
     %__MODULE__{}
     |> Map.put(:body, body)


### PR DESCRIPTION
For some API calls an empty body is returned ([like deleting images](https://docs.digitalocean.com/reference/api/api-reference/#operation/images_delete)).

This PR handle that scenario.

Before that I was getting this Jason error: `** (Jason.DecodeError) unexpected end of input at position 0`.

I'm not sure that's the best way to do so, but I'm happy to improve it based on your feedback :)